### PR TITLE
Remove version attribute

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,3 @@
----
-version: "3"
-
 services:
   app:
     build:


### PR DESCRIPTION
Fixes this warning:

```bash
WARN[0000] /home/xiaomin/dev/dev-team-spring-25/.devcontainer/docker-compose.yml: the attribute `version`
is obsolete, it will be ignored, please remove it to avoid potential confusion
```