### PR TITLE
Update pre-commit hook to auto-fix issues

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-echo "If you want to override the pre-commit hook and commit anyway, use VSCode's \"Commit (no verify)\" or \"git commit -n -m [message]\""
-pnpm exec lint-staged
+pnpm exec lint-staged || (echo "If you want to override the pre-commit hook and commit anyway, use VSCode's \"Commit (no verify)\" or \"git commit -n -m [message]\""; false)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-echo "If popup: hook failed, click \"command output\", fix with \"pnpm format\" or \"pnpm lint:fix\". Use VSCode's \"Commit (no verify)\" or \"git commit -n -m [message] \" to commit anyway"
+echo "If you want to override the pre-commit hook and commit anyway, use VSCode's \"Commit (no verify)\" or \"git commit -n -m [message]\""
 pnpm exec lint-staged

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,12 +1,12 @@
 import { relative } from "path";
 
 const buildEslintCommand = (filenames) =>
-  `next lint --file ${filenames
+  `next lint --fix --file ${filenames
     .map((f) => relative(process.cwd(), f))
     .join(" --file ")}`;
 
 const buildPrettierCommand = (filenames) =>
-  `prettier --ignore-unknown --check ${filenames
+  `prettier --ignore-unknown --write ${filenames
     .map((f) => relative(process.cwd(), f))
     .join(" ")}`;
 


### PR DESCRIPTION
I was going to run both a fix and check command but I think this still stops commits with non auto-fixable lint errors (adding unused `React` import for example):

```bash
❯ git commit -m "test"
If you want to override the pre-commit hook and commit anyway, use VSCode's "Commit (no verify)" or "git commit -n -m [message] "
✔ Backed up original state in git stash (28ef485)
⚠ Running tasks for staged files...
  ❯ .lintstagedrc.js — 2 files
    ❯ *.{js,jsx,ts,tsx} — 1 file
      ✖ next lint --fix --file app/api/health/route.test.ts [FAILED]
      ◼ prettier --ignore-unknown --write app/api/health/route.test.ts
    ↓ *.{json,yml,yaml,md} — no files
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ next lint --fix --file app/api/health/route.test.ts:

./app/api/health/route.test.ts
2:8  Error: 'React' is defined but never used.  @typescript-eslint/no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
[xiaomin/write-on-precommit e7fa7c5] test
```

IMO it makes more sense having the pre-commit hook basically automatically linting and formatting your code so you don't have to do it manually.