### PR TITLE
remove `user_id` param in `/chat` server actions 

### DIFF
--- a/app/chat/[classroomId]/MessageBox.tsx
+++ b/app/chat/[classroomId]/MessageBox.tsx
@@ -4,7 +4,6 @@ import { RagFlowMessages, sendMessage } from "./actions";
 
 function MessageBox(props: {
   assistantId: string;
-  userId: string;
   chatSessionId: string;
   messageHistory: RagFlowMessages | null;
 }) {
@@ -24,7 +23,6 @@ function MessageBox(props: {
     const response: string = await sendMessage(
       value,
       props.assistantId,
-      props.userId,
       props.chatSessionId
     );
 

--- a/app/chat/[classroomId]/actions.ts
+++ b/app/chat/[classroomId]/actions.ts
@@ -247,7 +247,6 @@ async function createSession(
 export async function sendMessage(
   message: string,
   assistantID: string,
-  userID: string,
   chatSessionID: string
 ) {
   // console.log("Message sent: ", message);
@@ -256,7 +255,6 @@ export async function sendMessage(
   const params = {
     question: message,
     session_id: chatSessionID,
-    user_id: userID,
     stream: false,
   };
 

--- a/app/chat/[classroomId]/actions.ts
+++ b/app/chat/[classroomId]/actions.ts
@@ -52,8 +52,7 @@ const API_KEY = process.env.RAGFLOW_API_KEY;
 
 export async function getOrCreateAssistant(
   classroomId: number,
-  datasetId: string,
-  userId: string
+  datasetId: string
 ) {
   const existingChat = await findChatAssistant(classroomId);
   if (existingChat) {
@@ -62,11 +61,7 @@ export async function getOrCreateAssistant(
 
   console.log("Get or create: didn't find an assistant, creating a new one");
 
-  const newAssistant = await createChatAssistant(
-    classroomId,
-    datasetId,
-    userId
-  );
+  const newAssistant = await createChatAssistant(classroomId, datasetId);
   if (!newAssistant?.data && newAssistant?.status) {
     return { status: "empty", id: null };
   }
@@ -96,7 +91,7 @@ export async function findChatAssistant(classroomId: ClassroomId) {
 
     if (res.error) throw new Error(`Failed to fetch chats: ${res.error}`);
 
-    const data = await res.data.chat_assistant_id;
+    const data = res.data.chat_assistant_id;
 
     // console.log(data);
 
@@ -109,12 +104,11 @@ export async function findChatAssistant(classroomId: ClassroomId) {
 
 async function createChatAssistant(
   classroomId: ClassroomId,
-  datasetId: string,
-  userId: string
+  datasetId: string
 ) {
   const newAssistant = {
     dataset_ids: [datasetId],
-    name: `${datasetId}-${userId}`,
+    name: `${datasetId}-${classroomId}`,
   };
 
   try {
@@ -141,7 +135,7 @@ async function createChatAssistant(
     }
 
     // update that in supabase
-    const supabase = await createServiceClient();
+    const supabase = createServiceClient();
 
     const supabaseRes = await supabase
       .from("Classroom")
@@ -224,7 +218,7 @@ async function createSession(
     const resJson = await res.json();
 
     // update that in supabase
-    const supabase = await createServiceClient();
+    const supabase = createServiceClient();
 
     const supabaseRes = await supabase
       .from("Classroom_Members")

--- a/app/chat/[classroomId]/page.tsx
+++ b/app/chat/[classroomId]/page.tsx
@@ -26,8 +26,7 @@ export default async function ChatPage({
 
   const chatAssistantId = await getOrCreateAssistant(
     Number(classroomId),
-    datasetId,
-    userId
+    datasetId
   );
   if (chatAssistantId.status == "empty") {
     return (

--- a/app/chat/[classroomId]/page.tsx
+++ b/app/chat/[classroomId]/page.tsx
@@ -78,7 +78,6 @@ export default async function ChatPage({
       {chatAssistantId && chatSessionId && messageHistory && (
         <MessageBox
           assistantId={chatAssistantId.id}
-          userId={userId}
           chatSessionId={chatSessionId}
           messageHistory={messageHistory}
         ></MessageBox>


### PR DESCRIPTION
### for `sendMessage()`

Based on the ragflow documentation `user_id` is not necessary if `session_id` is provided (which we did). Most importantly, I think the wrong `user_id` is passed in. We are passing in the `user_id` in our `Users` table, but ragflow asks for the `user_id` for ragflow account. 

Here is the documentation with [link](https://ragflow.io/docs/dev/http_api_reference#add-chunk):
```text
"user_id": (Body parameter), string
The optional user-defined ID. Valid only when no session_id is provided.
```
### for `createChatAssitant()`

This helper takes in `userId` to name a `newAssitant` as `${datasetId}-${userId}`. I am thinking since we have one assitant per classroom, it shouldn't matter who triggers the creation of the chat assiatant. From semantic perspective, its better to have `${datasetId}-${classroomId}` as the assistant name and thus we don't have to pass in one addition argument (`userId`) purly for naming the assistant.